### PR TITLE
fix: R instead of C in weapon refinement dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genshin-wish-planner",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Genshin Wish Planner will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.1] - 2025-06-30
+
+### Added
+
+- Select/deselect all primogem sources in the "Estimated Future Wishes" panel
+
 ## [0.5.0] - 2025-06-30
 
 ### Added
@@ -14,19 +20,19 @@ All notable changes to the Genshin Wish Planner will be documented in this file.
 
 ### Added
 
-- Added a changelog
+- Changelog system
 
 ## [0.3.0] - 2025-06-22
 
 ### Added
 
-- Added starglitter earned during wishing to total wish counts
+- Starglitter earned from wishing contributes to total wish counts
 
 ## [0.2.0] - 2025-06-18
 
 ### Content
 
-- Added upcoming banner information for Version 5.8: Ineffa, Mualani, Chasca, and Citlali
+- Upcoming banner information for Version 5.8: Ineffa, Mualani, Chasca, and Citlali
 
 ## [0.1.0] - 2025-06-07
 
@@ -39,9 +45,12 @@ All notable changes to the Genshin Wish Planner will be documented in this file.
 
 ### Added
 
-- Added support for Capturing Radiance
+- Support for Capturing Radiance
 - Full weapon banner wishing and planning tools
-- Significantly improved mobile experience across the app
+
+### Improved
+
+- Mobile experience across the app
 
 ## [0.0.8] - 2025-06-01
 
@@ -50,38 +59,6 @@ All notable changes to the Genshin Wish Planner will be documented in this file.
 - Incorrect banner start and end dates
 - Various mobile responsiveness issues
 - Infinite reload bug
-
-## [0.0.7] - 2025-05-30
-
-### Added
-
-- Core wish simulation and optimization features
-- Track primogems from Abyss, events, and other sources
-- Plan wishes for upcoming banners
-- Better error messages and input checking
-
-### Improved
-
-- Visual design and typography
-- User interface responsiveness
-
-## [0.0.6] - 2025-05-22
-
-### Added
-
-- Added helpful tooltips throughout the app
-- Better mobile and tablet support
-
-## [0.0.5] - 2025-05-19
-
-### Added
-
-- Visual character images in results
-- Visual primogem and fate tracking
-
-### Fixed
-
-- Issues with some icons and images not showing up
 
 ## [0.0.1] - 2025-05-06
 

--- a/src/app/panels/configuration/estimated-future-wishes.tsx
+++ b/src/app/panels/configuration/estimated-future-wishes.tsx
@@ -1,4 +1,5 @@
 import { LimitedWish, Primogem } from "@/components/resource";
+import { Button } from "@/components/ui/button";
 import { CheckboxWithLabel } from "@/components/ui/checkbox-with-label";
 import { InfoIcon } from "@/components/ui/info-icon";
 import { Label } from "@/components/ui/label";
@@ -122,34 +123,84 @@ export const EstimatedFutureWishes = observer(
     }, []);
 
     // Calculate totals for each category
-    const categoryTotals = useMemo(() => {
-      const freeToPlayTotal = PRIMOGEM_SOURCE_CATEGORIES.freeToPlay.reduce(
-        (total, key) => {
-          if (primogemSources[key]) {
-            const primoValue = getPrimogemValue(PRIMOGEM_SOURCE_VALUES[key]);
-            const wishValue = getLimitedWishValue(PRIMOGEM_SOURCE_VALUES[key]);
-            return total + Math.floor(primoValue / 160) + wishValue;
-          }
-          return total;
-        },
-        0
-      );
-
-      const paidTotal = PRIMOGEM_SOURCE_CATEGORIES.paid.reduce((total, key) => {
+    const freeToPlayTotal = PRIMOGEM_SOURCE_CATEGORIES.freeToPlay.reduce(
+      (total, key) => {
         if (primogemSources[key]) {
           const primoValue = getPrimogemValue(PRIMOGEM_SOURCE_VALUES[key]);
           const wishValue = getLimitedWishValue(PRIMOGEM_SOURCE_VALUES[key]);
           return total + Math.floor(primoValue / 160) + wishValue;
         }
         return total;
-      }, 0);
+      },
+      0
+    );
 
-      return {
-        freeToPlayTotal,
-        paidTotal,
-        grandTotal: freeToPlayTotal + paidTotal,
-      };
-    }, [primogemSources]);
+    const paidTotal = PRIMOGEM_SOURCE_CATEGORIES.paid.reduce((total, key) => {
+      if (primogemSources[key]) {
+        const primoValue = getPrimogemValue(PRIMOGEM_SOURCE_VALUES[key]);
+        const wishValue = getLimitedWishValue(PRIMOGEM_SOURCE_VALUES[key]);
+        return total + Math.floor(primoValue / 160) + wishValue;
+      }
+      return total;
+    }, 0);
+
+    const categoryTotals = {
+      freeToPlayTotal,
+      paidTotal,
+      grandTotal: freeToPlayTotal + paidTotal,
+    };
+
+    // Get available sources (sources with actual values)
+    const availableFreeToPlaySources = useMemo(() => {
+      return PRIMOGEM_SOURCE_CATEGORIES.freeToPlay.filter((sourceKey) => {
+        const sourceValue = PRIMOGEM_SOURCE_VALUES[sourceKey];
+        const primoValue = getPrimogemValue(sourceValue);
+        const wishValue = getLimitedWishValue(sourceValue);
+        return primoValue > 0 || wishValue > 0;
+      });
+    }, []);
+
+    // Check if all sources in a category are selected
+    const areAllFreeToPlaySelected =
+      availableFreeToPlaySources.length > 0 &&
+      availableFreeToPlaySources.every(
+        (sourceKey) => primogemSources[sourceKey]
+      );
+
+    const areAllPremiumSelected =
+      PRIMOGEM_SOURCE_CATEGORIES.paid.length > 0 &&
+      PRIMOGEM_SOURCE_CATEGORIES.paid.every(
+        (sourceKey) => primogemSources[sourceKey]
+      );
+
+    // Helper functions for toggle select/deselect all
+    const handleToggleFreeToPlay = () => {
+      if (areAllFreeToPlaySelected) {
+        // Deselect all available sources
+        availableFreeToPlaySources.forEach((sourceKey) => {
+          handlePrimogemSourceChange(sourceKey, false);
+        });
+      } else {
+        // Select all available sources
+        availableFreeToPlaySources.forEach((sourceKey) => {
+          handlePrimogemSourceChange(sourceKey, true);
+        });
+      }
+    };
+
+    const handleTogglePremium = () => {
+      if (areAllPremiumSelected) {
+        // Deselect all
+        PRIMOGEM_SOURCE_CATEGORIES.paid.forEach((sourceKey) => {
+          handlePrimogemSourceChange(sourceKey, false);
+        });
+      } else {
+        // Select all
+        PRIMOGEM_SOURCE_CATEGORIES.paid.forEach((sourceKey) => {
+          handlePrimogemSourceChange(sourceKey, true);
+        });
+      }
+    };
 
     return (
       <div className="space-y-2">
@@ -161,11 +212,19 @@ export const EstimatedFutureWishes = observer(
         <div className="flex flex-col space-y-4">
           {/* Free-to-Play Category */}
           <div>
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center justify-between">
               <Label className="flex items-center text-sm font-medium text-gold-1">
                 {`Free-to-play: `}
                 <LimitedWish number={categoryTotals.freeToPlayTotal} />
               </Label>
+              <Button
+                onClick={handleToggleFreeToPlay}
+                variant="ghost"
+                size="sm"
+                className="text-xs px-2 py-1 h-6 text-gold-1 hover:text-gold-1/80 -mr-2"
+              >
+                {areAllFreeToPlaySelected ? "Deselect All" : "Select All"}
+              </Button>
             </div>
 
             {/* Free-to-Play Detailed Sources */}
@@ -210,11 +269,19 @@ export const EstimatedFutureWishes = observer(
 
           {/* Paid Sources */}
           <div>
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center justify-between">
               <Label className="flex items-center text-sm font-medium text-gold-1">
                 {`Premium: `}
                 <LimitedWish number={categoryTotals.paidTotal} />
               </Label>
+              <Button
+                onClick={handleTogglePremium}
+                variant="ghost"
+                size="sm"
+                className="text-xs px-2 py-1 h-6 text-gold-1 hover:text-gold-1/80 -mr-2"
+              >
+                {areAllPremiumSelected ? "Deselect All" : "Select All"}
+              </Button>
             </div>
 
             <div className="grid grid-cols-1 ml-1">
@@ -253,33 +320,46 @@ export const EstimatedFutureWishes = observer(
           className="bg-void-1 rounded-md p-3 border border-void-2 mt-4"
         >
           <div className="text-sm flex gap-1 items-center justify-center font-medium text-gold-1">
-            <LimitedWish number={estimatedNewWishesPerBanner[0]} />
-            -
-            <LimitedWish number={estimatedNewWishesPerBanner[1]} />
-            gained each banner
-            <InfoIcon
-              content={
-                <div className="flex flex-col gap-2">
-                  <div>
-                    The amount earned per banner depends on the number of abyss
-                    and imaginarium seasons that occur during the banner period.
-                  </div>
-                  <div className="flex flex-row items-center self-center gap-1">
-                    <div>2 abyss and 2 imaginarium =</div>
-                    <Primogem number={2400} />
-                    <div>=</div>
-                    <LimitedWish number={15} />
-                  </div>
-                  <div className="flex flex-row items-center self-center gap-1">
-                    <div>1 abyss and 1 imaginarium =</div>
-                    <Primogem number={800} />
-                    <div>=</div>
-                    <LimitedWish number={5} />
-                  </div>
-                </div>
-              }
-              contentMaxWidth={containerWidth ? containerWidth + 36 : undefined}
-            />
+            {estimatedNewWishesPerBanner[0] ===
+            estimatedNewWishesPerBanner[1] ? (
+              <>
+                <LimitedWish number={estimatedNewWishesPerBanner[0]} /> gained
+                each version
+              </>
+            ) : (
+              <>
+                <LimitedWish number={estimatedNewWishesPerBanner[0]} />
+                -
+                <LimitedWish number={estimatedNewWishesPerBanner[1]} />
+                gained each version
+                <InfoIcon
+                  content={
+                    <div className="flex flex-col gap-2">
+                      <div>
+                        The amount earned per version depends on the number of
+                        abyss and imaginarium seasons that occur during the
+                        version period.
+                      </div>
+                      <div className="flex flex-row items-center self-center gap-1">
+                        <div>2 abyss and 2 imaginarium =</div>
+                        <Primogem number={2400} />
+                        <div>=</div>
+                        <LimitedWish number={15} />
+                      </div>
+                      <div className="flex flex-row items-center self-center gap-1">
+                        <div>1 abyss and 1 imaginarium =</div>
+                        <Primogem number={800} />
+                        <div>=</div>
+                        <LimitedWish number={5} />
+                      </div>
+                    </div>
+                  }
+                  contentMaxWidth={
+                    containerWidth ? containerWidth + 36 : undefined
+                  }
+                />
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/src/app/panels/simulation/components/constellation-input.tsx
+++ b/src/app/panels/simulation/components/constellation-input.tsx
@@ -5,81 +5,137 @@ import { CharacterId, WeaponId } from "@/lib/types";
 import { observer } from "mobx-react-lite";
 import { useMemo } from "react";
 
-type ConstellationInputProps = {
+type RefinementInputProps = {
   isLoading: boolean;
-  maxConstellation: number;
-  setMaxConstellation: (c: number) => void;
-} & (
-  | { type: "character"; characterId: CharacterId }
-  | { type: "weapon"; weaponId: WeaponId }
+  weaponId: WeaponId;
+  maxRefinement: number;
+  setMaxRefinement: (r: number) => void;
+};
+export const RefinementInput = observer(
+  ({
+    isLoading,
+    weaponId,
+    maxRefinement,
+    setMaxRefinement,
+  }: RefinementInputProps) => (
+    <BaseConstellationOrRefinementInput
+      isLoading={isLoading}
+      type="weapon"
+      id={weaponId}
+      currValue={maxRefinement}
+      setCurrValue={setMaxRefinement}
+      onClickMax={() => setMaxRefinement(4)}
+      onReset={() => setMaxRefinement(0)}
+    />
+  )
 );
 
-export const ConstellationInput = observer((props: ConstellationInputProps) => {
-  const { isLoading, maxConstellation, setMaxConstellation, type, ...rest } =
-    props;
-
-  const hintText = useMemo(() => {
-    if (type === "character") {
-      return (
-        <>
-          <div>
-            Tells the simulator to stop pulling once this constellation is
-            reached, even if you have enough wishes to continue.
-          </div>
-          <div>
-            {`Assumes you don't have the character yet. If you have C0 and want C2, put C1 (which equals two copies).`}
-          </div>
-        </>
-      );
-    } else {
-      return (
-        <>
-          <div>
-            Tells the simulator to stop pulling once this refinement level is
-            reached, even if you have enough wishes to continue.
-          </div>
-          <div>
-            {`Assumes you don't have the weapon yet. If you have R1 and want R2, put R1 (which equals one copy).`}
-          </div>
-        </>
-      );
-    }
-  }, [type]);
-
-  const id =
-    type === "character"
-      ? (rest as { characterId: CharacterId }).characterId
-      : (rest as { weaponId: WeaponId }).weaponId;
-
-  return (
-    <BannerInputBase
-      title={
-        <>
-          Pull until
-          <InfoIcon
-            content={<div className="flex flex-col gap-2">{hintText}</div>}
-            contentMaxWidth={400}
-            className="text-white/50"
-          />
-        </>
-      }
+type ConstellationInputProps = {
+  isLoading: boolean;
+  characterId: CharacterId;
+  maxConstellation: number;
+  setMaxConstellation: (c: number) => void;
+};
+export const ConstellationInput = observer(
+  ({
+    isLoading,
+    characterId,
+    maxConstellation,
+    setMaxConstellation,
+  }: ConstellationInputProps) => (
+    <BaseConstellationOrRefinementInput
       isLoading={isLoading}
-      showMaxButton={false}
-      showResetButton={false}
+      type="character"
+      id={characterId}
+      currValue={maxConstellation}
+      setCurrValue={setMaxConstellation}
       onClickMax={() => setMaxConstellation(6)}
-      onClickReset={() => setMaxConstellation(0)}
-    >
-      <Input
+      onReset={() => setMaxConstellation(0)}
+    />
+  )
+);
+export type BaseConstellationOrRefinementInputProps = {
+  type: "character" | "weapon";
+  id: CharacterId | WeaponId;
+  isLoading: boolean;
+  currValue: number;
+  setCurrValue: (v: number) => void;
+  onClickMax: () => void;
+  onReset: () => void;
+};
+
+const BaseConstellationOrRefinementInput = observer(
+  ({
+    type,
+    id,
+    isLoading,
+    currValue,
+    setCurrValue,
+    onClickMax,
+    onReset,
+  }: BaseConstellationOrRefinementInputProps) => {
+    const hintText = useMemo(() => {
+      if (type === "character") {
+        return (
+          <>
+            <div>
+              Tells the simulator to stop pulling once this constellation is
+              reached, even if you have enough wishes to continue.
+            </div>
+            <div>
+              {`Assumes you don't have the character yet. If you have C0 and want C2, put C1 (which equals two copies).`}
+            </div>
+          </>
+        );
+      } else {
+        return (
+          <>
+            <div>
+              Tells the simulator to stop pulling once this refinement level is
+              reached, even if you have enough wishes to continue.
+            </div>
+            <div>
+              {`Assumes you don't have the weapon yet. If you have R1 and want R2, put R1 (which equals one copy).`}
+            </div>
+          </>
+        );
+      }
+    }, [type]);
+
+    return (
+      <BannerInputBase
+        title={
+          <>
+            Pull until
+            <InfoIcon
+              content={<div className="flex flex-col gap-2">{hintText}</div>}
+              contentMaxWidth={400}
+              className="text-white/50"
+            />
+          </>
+        }
         isLoading={isLoading}
-        id={`constellation-${id}`}
-        type="number"
-        min="0"
-        value={maxConstellation}
-        onChange={(e) => setMaxConstellation(parseInt(e.target.value))}
-        unit={<div className="text-white/50 pl-1 flex-initial">C</div>}
-        showPlusMinus={true}
-        width={"w-10"}
-      />
-    </BannerInputBase>
-  );
-});
+        showMaxButton={false}
+        showResetButton={false}
+        onClickMax={onClickMax}
+        onClickReset={onReset}
+      >
+        <Input
+          isLoading={isLoading}
+          id={`constellation-input-${id}`}
+          type="number"
+          min="0"
+          value={currValue}
+          onChange={(e) => setCurrValue(parseInt(e.target.value))}
+          unit={
+            <div className="text-white/50 pl-1 flex-initial">
+              {type === "character" ? "C" : "R"}
+            </div>
+          }
+          showPlusMinus={true}
+          width={"w-10"}
+        />
+      </BannerInputBase>
+    );
+  }
+);

--- a/src/app/panels/simulation/components/wishes-input.tsx
+++ b/src/app/panels/simulation/components/wishes-input.tsx
@@ -138,7 +138,7 @@ export const WishesInput = observer((props: WishesInputProps) => {
         }}
         unit={<LimitedWish />}
         showPlusMinus={true}
-        width={"w-10"}
+        width={"w-18"}
       />
     </BannerInputBase>
   );

--- a/src/components/banner/banner-input-base.tsx
+++ b/src/components/banner/banner-input-base.tsx
@@ -46,7 +46,7 @@ export const BannerInputBase = observer(
         <div className="flex flex-row items-center gap-1 text-xs text-white text-left">
           {title}
         </div>
-        <div className="flex items-center gap-1 justify-around">
+        <div className="flex items-center gap-1 justify-between">
           {children}
           <div className="flex gap-2">
             {showResetButton && (

--- a/src/components/banner/character-row.tsx
+++ b/src/components/banner/character-row.tsx
@@ -41,7 +41,6 @@ const CharacterRowMobile = observer(
 
         <ConstellationInput
           isLoading={isLoading}
-          type="character"
           characterId={character.Id}
           maxConstellation={currentMaxConstellation}
           setMaxConstellation={setMaxConstellation}
@@ -108,10 +107,9 @@ const CharacterRowDesktop = observer(
         <div className="flex items-center gap-4 col-span-2 md:col-span-1">
           <CharacterIcon id={characterId} showName className="shrink-0" />
         </div>
-        <div className="col-span-2 flex gap-8 justify-end">
+        <div className="col-span-2 flex gap-6 justify-end">
           <ConstellationInput
             isLoading={isLoading}
-            type="character"
             characterId={character.Id}
             maxConstellation={currentMaxConstellation}
             setMaxConstellation={setMaxConstellation}

--- a/src/components/banner/weapon-row.tsx
+++ b/src/components/banner/weapon-row.tsx
@@ -17,7 +17,7 @@ import {
   SelectValue,
 } from "../ui/select";
 
-import { ConstellationInput } from "@/app/panels/simulation/components/constellation-input";
+import { RefinementInput } from "@/app/panels/simulation/components/constellation-input";
 import { WishesInput } from "@/app/panels/simulation/components/wishes-input";
 import WeaponIcon from "@/lib/components/weapon-icon";
 
@@ -75,12 +75,11 @@ const WeaponBannerRowMobile = observer(
           </Select>
         </div>
 
-        <ConstellationInput
+        <RefinementInput
           isLoading={isLoading}
-          type="weapon"
           weaponId={currentEpitomizedPath}
-          maxConstellation={currentMaxRefinement}
-          setMaxConstellation={setMaxRefinement}
+          maxRefinement={currentMaxRefinement}
+          setMaxRefinement={setMaxRefinement}
         />
 
         {mode === "playground" && (
@@ -166,13 +165,12 @@ const WeaponBannerRowDesktop = observer(
           </Select>
         </div>
 
-        <div className="flex gap-8 col-span-2 justify-end">
-          <ConstellationInput
+        <div className="flex gap-6 col-span-2 justify-end">
+          <RefinementInput
             isLoading={isLoading}
-            type="weapon"
             weaponId={currentEpitomizedPath}
-            maxConstellation={currentMaxRefinement}
-            setMaxConstellation={setMaxRefinement}
+            maxRefinement={currentMaxRefinement}
+            setMaxRefinement={setMaxRefinement}
           />
           {mode === "playground" && (
             <WishesInput

--- a/src/components/changelog/changelog-modal.tsx
+++ b/src/components/changelog/changelog-modal.tsx
@@ -21,17 +21,17 @@ interface ChangelogModalProps {
 const ChangeTypeColors = {
   feature: "bg-green-500/20 text-green-300 border-green-500/40",
   improvement: "bg-blue-500/20 text-blue-300 border-blue-500/40",
-  fix: "bg-yellow-500/20 text-yellow-300 border-yellow-500/40",
+  fix: "bg-gold-1/20 text-yellow-300 border-yellow-500/40",
   breaking: "bg-red-500/20 text-red-300 border-red-500/40",
   content: "bg-purple-500/20 text-purple-300 border-purple-500/40",
 } as const;
 
 const ChangeTypeLabels = {
   feature: "New",
-  improvement: "Improved",
-  fix: "Fixed",
+  improvement: "Improve",
+  fix: "Fix",
   breaking: "Breaking",
-  content: "Content",
+  content: "Update",
 } as const;
 
 export const ChangelogModal = observer(function ChangelogModal({
@@ -65,38 +65,54 @@ export const ChangelogModal = observer(function ChangelogModal({
               {`You're all caught up! No new changes to show.`}
             </div>
           ) : (
-            changelog.map((entry) => (
-              <div key={entry.version} className="space-y-3">
-                <div className="flex items-center gap-3">
-                  <span className="text-sm text-gold-1">{entry.date}</span>
-                  <span className="text-sm text-white/50">
-                    v{entry.version}
-                  </span>
-                </div>
+            (() => {
+              // Group entries by date
+              const groupedEntries = changelog.reduce((acc, entry) => {
+                if (!acc[entry.date]) {
+                  acc[entry.date] = [];
+                }
+                acc[entry.date].push(entry);
+                return acc;
+              }, {} as Record<string, ChangelogEntry[]>);
 
-                <div className="space-y-2 pl-4">
-                  {entry.changes.map((change, index) => (
-                    <div key={index} className="flex items-start gap-3">
-                      <Badge
-                        variant="outline"
-                        className={`${
-                          ChangeTypeColors[change.type]
-                        } text-xs shrink-0 mt-0.5`}
-                      >
-                        {ChangeTypeLabels[change.type]}
-                      </Badge>
-                      <p className="text-sm leading-relaxed mt-0.5">
-                        {change.description}
-                      </p>
+              return Object.entries(groupedEntries).map(
+                ([date, entries], groupIndex) => (
+                  <div key={date} className="space-y-3">
+                    <div className="flex items-center gap-3">
+                      <span className="text-sm text-gold-1">{date}</span>
+                      <span className="text-sm text-white/50">
+                        v{entries[0].version}
+                      </span>
                     </div>
-                  ))}
-                </div>
 
-                {entry !== changelog[changelog.length - 1] && (
-                  <Separator className="bg-void-2/30 mt-4" />
-                )}
-              </div>
-            ))
+                    <div className="space-y-2 pl-4">
+                      {entries
+                        .flatMap((entry) => entry.changes)
+                        .map((change, index) => (
+                          <div key={index} className="flex items-start gap-3">
+                            <Badge
+                              variant="outline"
+                              className={`${
+                                ChangeTypeColors[change.type]
+                              } text-xs shrink-0 mt-0.5`}
+                            >
+                              {ChangeTypeLabels[change.type]}
+                            </Badge>
+                            <p className="text-sm leading-relaxed mt-0.5">
+                              {change.description}
+                            </p>
+                          </div>
+                        ))}
+                    </div>
+
+                    {groupIndex !==
+                      Object.entries(groupedEntries).length - 1 && (
+                      <Separator className="bg-void-2/30 mt-4" />
+                    )}
+                  </div>
+                )
+              );
+            })()
           )}
         </div>
       </DialogContent>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -150,8 +150,7 @@ const Input = React.forwardRef<
           isLoading && "shimmer"
         }`}
       >
-        <div className="min-w-[24px] min-h-[24px]">{unit && unit}</div>
-
+        {unit && unit}
         <input
           type={type}
           inputMode={type === "number" ? "numeric" : undefined}

--- a/src/lib/simulation/weapon-banner-model.ts
+++ b/src/lib/simulation/weapon-banner-model.ts
@@ -89,10 +89,10 @@ export const weaponWish = (
           newFatePoints,
         };
       } else {
-        // Got standard weapon - you'd need to implement getRandomStandardWeapon()
+        // Got standard weapon
         return {
           result: "standard",
-          weaponObtained: "standard_weapon" as WeaponId, // Placeholder
+          weaponObtained: "standard_weapon" as WeaponId,
           newPity: 0,
           newGuaranteed: true,
           newFatePoints: fatePoints + 1,


### PR DESCRIPTION
### TL;DR

Added select/deselect all buttons for primogem sources in the "Estimated Future Wishes" panel and improved UI components.

### What changed?

- Added "Select All" and "Deselect All" buttons for both free-to-play and premium primogem sources
- Refactored constellation/refinement input components for better code organization
- Improved the display of estimated wishes per version when values are identical
- Updated the changelog display to group entries by date
- Fixed various UI elements including input widths, spacing, and alignment
- Improved the changelog system with better categorization and labeling
- Released version 0.4.2 with the new select/deselect all feature

### How to test?

1. Open the "Estimated Future Wishes" panel
2. Verify that "Select All" and "Deselect All" buttons appear for both free-to-play and premium sections
3. Test that clicking these buttons correctly selects or deselects all sources in their respective categories
4. Check that the estimated wishes display shows correctly when values are identical
5. Verify that constellation and refinement inputs work properly in character and weapon rows

### Why make this change?

This change improves user experience by making it easier to quickly select or deselect all primogem sources, rather than having to click each checkbox individually. The code refactoring also improves maintainability and organization of the constellation/refinement input components. The UI improvements enhance readability and consistency throughout the application.